### PR TITLE
ci: report code coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  require_ci_to_pass: yes
+
+ignore:
+  - internal/examples/proto/gen
+
+coverage:
+  range: "70...100"
+
+comment:
+  layout: reach,diff,flags,files
+  behavior: default
+  require_changes: no

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Make
         run: make
 
+      - name: Report Code Coverage
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./build/coverage/go-test.txt
+          fail_ci_if_error: true
+
   release:
     needs: [make]
     runs-on: ubuntu-latest

--- a/dprotocol/doc.go
+++ b/dprotocol/doc.go
@@ -1,0 +1,2 @@
+// Package dprotocol provides primitives for parsing the Aplicom D protocol.
+package dprotocol

--- a/dprotocol/gpsflags.go
+++ b/dprotocol/gpsflags.go
@@ -1,7 +1,8 @@
-// nolint: lll
 package dprotocol
 
 // GPSFlags validity bits combination information.
+//
+// nolint: lll
 //
 //  +----------+-----------+----------------------+------------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------+
 //  | Validity | Is fix    | Position in          | Satellites used  | Is possible | Additional info                                                                                                                           |


### PR DESCRIPTION
Standard config for our open source repos.
